### PR TITLE
Support for `ignored`, `blocked` and `jailed` globals

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,8 @@ myscope = new Scope(globals, { // `globals` will be `window` in browser
 	eval: false, // specify whether eval is available inside sandbox
 	console: false, // specify whether native console is available
 	strict: false, // specify whether to run the script in strict mode
-
-	// provide an object with globals to be made available to the scripts
-	import: {
-		myGlobalVarName: "sample"
-	}
+}, { // provide an object with globals to be made available to the scripts
+	myGlobalVarName: "sample"
 });
 
 // set a specific variable as global

--- a/lib/scope/index.js
+++ b/lib/scope/index.js
@@ -9,6 +9,7 @@ var util = require('../util'),
     ERROR_CODE_MUST_BE_STRING = 'expecting the scope\'s code to be a string',
     ERROR_VARNAME_STRING = 'expected variable name to be a string',
     ERROR_CALLBACK_MISSING = 'missing callback function',
+    ERROR_SCOPE_INTEGRITY = 'failing scope integrity',
 
     /**
      * Add variables here that will be available as globals inside the scope during execution
@@ -190,6 +191,11 @@ util.assign(Uniscope.prototype, /** @lends Uniscope.prototype */ {
             transferables[index] = value;
             context[key] = value;
         });
+
+        // we do a final integrity check
+        if (globals.length !== transferables.length) {
+            return callback(new Error(ERROR_SCOPE_INTEGRITY + [globals.length, transferables.length].join(', ')));
+        }
 
         // prepare the code by wrapping it within accurate prefix and suffix
         // @todo fix 'use strict'; code generation

--- a/lib/scope/index.js
+++ b/lib/scope/index.js
@@ -164,8 +164,8 @@ util.assign(Uniscope.prototype, /** @lends Uniscope.prototype */ {
             blocked = this._options.block.slice();
 
         // add console and eval to their respective injection points
-        (this._options.console ? ignored : blocked).push(CONSOLE);
-        (this._options.eval ? ignored : blocked).push(EVAL);
+        !this._imports.hasOwnProperty(CONSOLE) && (this._options.console ? ignored : blocked).push(CONSOLE);
+        !this._imports.hasOwnProperty(EVAL) && (this._options.eval ? ignored : blocked).push(EVAL);
 
         // ensure any missing entry from allowed globals are tracked too
         util.forEach(allowedGlobals, function (key) {

--- a/lib/scope/index.js
+++ b/lib/scope/index.js
@@ -32,7 +32,6 @@ var util = require('../util'),
  *
  * @typedef Uniscope~options
  *
- * @property {Object=} [options] Options to configure the script executions inside the scope.
  * @property {Boolean=false} [eval] Specify whether eval is available inside sandbox
  * @property {Boolean=false} [strict] Specify whether to run the script in strict mode
  * @property {Boolean=false} [console] When set to true, the native `console` object is available inside the scope
@@ -46,26 +45,7 @@ var util = require('../util'),
  * @param {Uniscope~options=} [options] Options to configure the script executions inside the scope.
  * @param {Object=} imports
  *
- * @example
- * var Scope = require('scope'), // use browserify or requireJS in browser!
- *     myscope;
- *
- * // create a new scope
- * myscope = new Scope(globals, { // `globals` will be `window` in browser
- *     strict: true, // specify whether to run the script in strict mode
- * }, { // provide an object with globals to be made available to the scripts
- *     myGlobalVarName: "sample"
- * });
- *
- * // set a specific variable as global
- * myscope.set('logger', function (msg) {
- *     console.log(msg);
- * });
- *
- * // now run a script
- * myscope.exec('logger(myGlobalVarName)', function (err) {
- *     err ? console.error(err.stack || err) : console.log('execution complete');
- * });
+ * @see {@link Scope.create}
  */
 Uniscope = function (options, imports) {
     this._imports = {};
@@ -89,6 +69,29 @@ util.assign(Uniscope, /** @lends Uniscope */ {
      * @param {Uniscope~options}
      * @param {Object=} [imports]
      * @return {Uniscope}
+     *
+     * @see {@link Uniscope}
+     *
+     * @example
+     * var Scope = require('scope'), // use browserify or requireJS in browser!
+     *     myscope;
+     *
+     * // create a new scope
+     * myscope = Scope.create(globals, { // `globals` will be `window` in browser
+     *     strict: true, // specify whether to run the script in strict mode
+     * }, { // provide an object with globals to be made available to the scripts
+     *     myGlobalVarName: "sample"
+     * });
+     *
+     * // set a specific variable as global
+     * myscope.set('logger', function (msg) {
+     *     console.log(msg);
+     * });
+     *
+     * // now run a script
+     * myscope.exec('logger(myGlobalVarName)', function (err) {
+     *     err ? console.error(err.stack || err) : console.log('execution complete');
+     * });
      */
     create: function (options, imports) {
         return new Uniscope(options, imports);

--- a/lib/scope/index.js
+++ b/lib/scope/index.js
@@ -52,11 +52,8 @@ var util = require('../util'),
  * // create a new scope
  * myscope = new Scope(globals, { // `globals` will be `window` in browser
  *     strict: true, // specify whether to run the script in strict mode
- *
- *     // provide an object with globals to be made available to the scripts
- *     import: {
- *         myGlobalVarName: "sample"
- *     }
+ * }, { // provide an object with globals to be made available to the scripts
+ *     myGlobalVarName: "sample"
  * });
  *
  * // set a specific variable as global

--- a/lib/scope/index.js
+++ b/lib/scope/index.js
@@ -68,7 +68,13 @@ var util = require('../util'),
  */
 Uniscope = function (options, imports) {
     this._imports = {};
-    this._options = util.isObject(options) ? options : {};
+    this._options = util.cloneObject(options, /** @lends Uniscope~options */ {
+        strict: false,
+        console: false,
+        eval: false,
+        ignore: [],
+        block: []
+    }, true);
 
     // process construction imports
     util.isObject(imports) && this.import(imports);

--- a/lib/scope/index.js
+++ b/lib/scope/index.js
@@ -35,6 +35,9 @@ var util = require('../util'),
  * @property {Boolean=false} [eval] Specify whether eval is available inside sandbox
  * @property {Boolean=false} [strict] Specify whether to run the script in strict mode
  * @property {Boolean=false} [console] When set to true, the native `console` object is available inside the scope
+ *
+ * @property {Array=} [ignore] Specify a set of global variables that will not be allowed to trickle in
+ * @property {Array=} [blocked] Specify a set of global variables that will not be allowed to trickle in
  */
 
 /**
@@ -155,16 +158,12 @@ util.assign(Uniscope.prototype, /** @lends Uniscope.prototype */ {
             globals = Object.getOwnPropertyNames(universe),
             context = {},
             transferables = [],
-            ignored = [];
+            ignored = this._options.ignore.slice(),
+            blocked = this._options.block.slice();
 
-        this._options.console && ignored.push(CONSOLE);
-        this._options.eval && ignored.push(EVAL);
-
-        // based on Uniscope configuration, the globals that we should pass through is left untouched
-        util.forEach(ignored, function (key) {
-            var position = globals.indexOf(key);
-            (position > -1) && globals.splice(position, 1);
-        });
+        // add console and eval to their respective injection points
+        (this._options.console ? ignored : blocked).push(CONSOLE);
+        (this._options.eval ? ignored : blocked).push(EVAL);
 
         // ensure any missing entry from allowed globals are tracked too
         util.forEach(allowedGlobals, function (key) {
@@ -184,6 +183,15 @@ util.assign(Uniscope.prototype, /** @lends Uniscope.prototype */ {
             }
         });
 
+        // based on Uniscope configuration, the globals that we should pass through is left untouched
+        util.forEach(ignored, function (key) {
+            var position = globals.indexOf(key);
+            if (position > -1) {
+                globals.splice(position, 1);
+                transferables.splice(position, 1);
+            }
+        });
+
         // now set the custom overrides
         util.forOwn(this._imports, function (value, key) {
             // in case the var is already in globals, then we need to replace, else add a new one
@@ -193,6 +201,16 @@ util.assign(Uniscope.prototype, /** @lends Uniscope.prototype */ {
             globals[index] = key;
             transferables[index] = value;
             context[key] = value;
+        });
+
+        // based on Uniscope configuration, the globals that we block are specifically set to undefined
+        util.forEach(blocked, function (key) {
+            var position = globals.indexOf(key);
+            (position === -1) && (position = globals.length);
+
+            globals[position] = key;
+            transferables[position] = undefined;
+            context.hasOwnProperty(key) && (delete context[key]);
         });
 
         // we do a final integrity check

--- a/lib/scope/index.js
+++ b/lib/scope/index.js
@@ -53,6 +53,7 @@ var util = require('../util'),
 Uniscope = function (options, imports) {
     this._imports = {};
     this._options = util.cloneObject(options, /** @lends Uniscope~options */ {
+        jailed: true,
         strict: false,
         console: false,
         eval: false,
@@ -154,7 +155,8 @@ util.assign(Uniscope.prototype, /** @lends Uniscope.prototype */ {
 
         callback = util.sealback(callback); // ensure callback is allowed once only
 
-        var universe = getContextObject(),
+        var unjailed = (this._options.jailed === false),
+            universe = unjailed ? {} : getContextObject(),
             globals = Object.getOwnPropertyNames(universe),
             context = {},
             transferables = [],

--- a/lib/util.js
+++ b/lib/util.js
@@ -5,6 +5,44 @@ var OBJECT = 'object',
 module.exports = {
     noop: function () {}, // eslint-disable-line no-empty-function
 
+    cloneObject: function (obj, defaults, defaultUndefined) {
+        var clone = {},
+            prop;
+
+        if (typeof obj !== OBJECT) {
+            if (typeof defaults === OBJECT) {
+                obj = defaults;
+                defaults = null;
+            }
+            // both obj and defaults are invalid, return blank object
+            else { return clone; }
+        }
+
+        for (prop in obj) { // eslint-disable-line guard-for-in
+            obj.hasOwnProperty(prop) && (clone[prop] = obj[prop]);
+        }
+
+        // nothing to set as defaults, so we simply exit
+        if (typeof defaults !== OBJECT) {
+            return clone;
+        }
+
+        // set defaults
+        // fork code path on top to ease loop performance
+        if (defaultUndefined) {
+            for (prop in defaults) { // eslint-disable-line guard-for-in
+                defaults.hasOwnProperty(prop) && (clone[prop] === undefined) && (clone[prop] = defaults[prop]);
+            }
+        }
+        else if (!defaultUndefined) {
+            for (prop in defaults) { // eslint-disable-line guard-for-in
+                defaults.hasOwnProperty(prop) && !clone.hasOwnProperty(prop) && (clone[prop] = defaults[prop]);
+            }
+        }
+
+        return clone;
+    },
+
     isObject: function (subject) {
         return (typeof subject === OBJECT);
     },

--- a/npm/test-system.js
+++ b/npm/test-system.js
@@ -47,6 +47,19 @@ module.exports = function (exit) {
             });
         },
 
+        // packity
+        function (next) {
+            var packity = require('packity'),
+                options = {
+                    path: './', dev: true
+                };
+
+            packity(options, function (err, results) {
+                packity.cliReporter(options)(err, results);
+                next(err);
+            });
+        },
+
         // execute nsp
         // programatically executing nsp is a bit tricky as we have to emulate the cli script's usage of internal
         // nsp functions.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniscope",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "description": "Allows one to evaluate a code within a controlled environment",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "packity": "0.3.2",
     "parse-gitignore": "0.3.1",
     "shelljs": "0.7.5",
-    "recursive-readdir": "^2.1.0",
-    "watchify": "3.7.0"
+    "recursive-readdir": "^2.1.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniscope",
-  "version": "0.1.0-beta.2",
+  "version": "0.1.0-beta.3",
   "description": "Allows one to evaluate a code within a controlled environment",
   "main": "index.js",
   "directories": {

--- a/test/unit/scope-options.test.js
+++ b/test/unit/scope-options.test.js
@@ -38,4 +38,19 @@ describe('scope module options', function () {
             expect(console === refConsole).be.ok();
         `, done);
     });
+
+    it('must ensure that blocked variables are not allowed', function (done) {
+        var scope = Scope.create({
+            console: true,
+            block: ['Buffer', 'myImportedGlobal']
+        }, {
+            expect: expect,
+            myImportedGlobal: {}
+        });
+
+        scope.exec(`
+            expect(Buffer).not.be.ok();
+            expect(myImportedGlobal).not.be.ok();
+        `, done);
+    });
 });

--- a/test/unit/scope-unjailed.test.js
+++ b/test/unit/scope-unjailed.test.js
@@ -1,0 +1,26 @@
+describe('scope module in unjailed mode', function () {
+    var Scope = require('../../');
+
+    describe('globals', function () {
+        before(function () {
+            global.uniscopeTestVariable = {
+                onekey: true
+            };
+        });
+
+        it('must pass through', function (done) {
+            var scope = Scope.create({
+                jailed: false
+            }, {expect: expect});
+
+            scope.exec(`
+                expect(uniscopeTestVariable).be.an('object');
+                expect(uniscopeTestVariable).have.property('onekey', true);
+            `, done);
+        });
+
+        after(function () {
+            delete global.uniscopeTestVariable;
+        });
+    });
+});


### PR DESCRIPTION
- ignored lets the globals go through-and-through (needed for eval, etc)
- blocked ensures that some globals are not available at all
- jailed mode can be turned off and no restriction is made to contain globals. but blocked and imports work.

This is required so that in new browserified sandbox, all globals are accessible and nothing interferes with user-defined ones as well.