### PR TITLE
Allow multiple concurrent executions

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,4 +1,6 @@
 unreleased:
+  new features:
+    - GH-639 Allow multiple concurrent executions to be run in the same scope
   chores:
     - Updated dependencies
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -285,17 +285,25 @@ class Uniscope {
         }
     }
 
-    _trackExecution (value, callback) {
+    /**
+     * Tracks the execution for the given execution and callback.
+     *
+     * @private
+     * @param {Object} execution Execution object
+     * @param {Function} callback Callback function
+     */
+    _trackExecution (execution, callback) {
         const self = this;
 
-        self._pendingExecutions.add(value);
+        self._pendingExecutions.add(execution);
 
-        return util.sealback( // ensure callback is allowed once only
-            function () {
-                self._pendingExecutions.delete(value);
-                callback.apply(this, arguments);
-            }
-        );
+        // ensure callback is allowed once only
+        return util.sealback(function () {
+            self._pendingExecutions.delete(execution);
+
+            // eslint-disable-next-line no-invalid-this
+            return callback.apply(this, arguments);
+        });
     }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -57,6 +57,7 @@ class Uniscope {
         this._locals = [];
         this._imports = {};
         this._context = getContextObject();
+        this._pendingExecutions = new Set();
 
         this.eval = Boolean(options.eval);
         this.strict = Boolean(options.strict);
@@ -175,8 +176,6 @@ class Uniscope {
         if (!util.isFunction(callback)) { throw new Error(ERROR_CALLBACK_MISSING); }
         if (!util.isString(code)) { return callback(new TypeError(ERROR_CODE_MUST_BE_STRING)); }
 
-        callback = util.sealback(callback); // ensure callback is allowed once only
-
         let universe = this._context,
             globals = Object.getOwnPropertyNames(universe),
             context = {},
@@ -188,6 +187,9 @@ class Uniscope {
         !util.has(this._imports, CONSOLE) && (this.console ? ignored : blocked).push(CONSOLE);
         !util.has(this._imports, EVAL) && (this.eval ? ignored : blocked).push(EVAL);
 
+        this._pendingExecutions.forEach((execution) => {
+            util.threeWayDiff(execution.globals, globals, this._locals);
+        });
 
         // ensure any missing entry from allowed globals are tracked too
         util.forEach(allowedGlobals, (key) => {
@@ -252,6 +254,8 @@ class Uniscope {
         code = (CODE_PREFIX + code + CODE_SUFFIX);
         this.strict && (code = CODE_STRICT + code);
 
+        callback = this._trackExecution({ globals }, callback);
+
         // @note IMPORTANT FOR CONTRIBUTORS
         // If you plan to edit this block of code, make sure you know what you are doing. Essentially, here we create a
         // function using the Function constructor and ensure that it is anonymous and bound to global a specific
@@ -279,6 +283,19 @@ class Uniscope {
 
             return callback();
         }
+    }
+
+    _trackExecution (value, callback) {
+        const self = this;
+
+        self._pendingExecutions.add(value);
+
+        return util.sealback( // ensure callback is allowed once only
+            function () {
+                self._pendingExecutions.delete(value);
+                callback.apply(this, arguments);
+            }
+        );
     }
 }
 

--- a/test/unit/scope-exec.test.js
+++ b/test/unit/scope-exec.test.js
@@ -45,4 +45,59 @@ describe('scope module exec', function () {
             done(err);
         });
     });
+
+    it('should be able to execute multiple concurrent executions', function (done) {
+        scope.set('execution_1', function () {
+            scope.exec(`
+                expect(a).to.equal(1);
+                a = 2;
+                b = 2;
+
+                execution_1_1();
+            `, function (err) {
+                expect(err, 'error in execution_1').to.be.undefined;
+            });
+        });
+
+        scope.set('execution_1_1', function () {
+            scope.exec(`
+                expect(a).to.equal(2);
+                expect(b).to.equal(2);
+                a = 3;
+                b = 3;
+                c = 3;
+            `, function (err) {
+                expect(err, 'error in execution_1_1').to.be.undefined;
+            });
+        });
+
+        scope.set('execution_2', function () {
+            scope.exec(`
+                expect(a).to.equal(3);
+                expect(b).to.equal(3);
+                expect(c).to.equal(3);
+                a = 4;
+                b = 4;
+                c = 4;
+                d = 4;
+            `, function (err) {
+                expect(err, 'error in execution_2').to.be.undefined;
+            });
+        });
+
+        scope.exec(`
+            a = 1;
+
+            execution_1();
+            expect(a).to.equal(3);
+            expect(b).to.equal(3);
+            expect(c).to.equal(3);
+
+            execution_2();
+            expect(a).to.equal(4);
+            expect(b).to.equal(4);
+            expect(c).to.equal(4);
+            expect(d).to.equal(4);
+        `, done);
+    });
 });


### PR DESCRIPTION
Allow calling `exec` multiple times even when there is a execution running currently.
This change ensures that any locals that are created before the next execution begins are available to the new execution.